### PR TITLE
Add failing test case: Encode array of byte arrays

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -115,7 +115,7 @@ func (e *Encoder) marshalArray(v reflect.Value) (*plistValue, error) {
 	if v.Type().Elem().Kind() == reflect.Uint8 {
 		bytes := []byte(nil)
 		if v.CanAddr() {
-			bytes = v.Bytes()
+			bytes = v.Slice(0, v.Len()).Bytes()
 		} else {
 			bytes = make([]byte, v.Len())
 			reflect.Copy(reflect.ValueOf(bytes), v)

--- a/encode_test.go
+++ b/encode_test.go
@@ -50,6 +50,11 @@ var arrRef = `<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0"><array><string>a</string><string>b</string><string>c</string><integer>4</integer><true></true></array></plist>
 `
 
+var byteArrRef = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><array><data>/////////////////////w==</data></array></plist>
+`
+
 var time1900Ref = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0"><date>1900-01-01T12:00:00Z</date></plist>
@@ -129,6 +134,9 @@ var encodeTests = []struct {
 		Bool bool   `plist:"bool"`
 	}{"bar", true},
 		dictRef},
+	{[][16]byte{
+		[16]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+	}, byteArrRef},
 }
 
 func TestEncodeValues(t *testing.T) {


### PR DESCRIPTION
Hey there,
Found a panic when encoding a slice of byte arrays.
This commit includes a test case which will cause the following error:

    panic: reflect: call of reflect.Value.Bytes on array Value

Due to the underlying element value of a slice not being a slice.
Behaviour is documented here: https://golang.org/pkg/reflect/#Value.Bytes
I will attempt to fix this.
