### PR TITLE
Use non-deprecated method

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ func someHTTPHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
     // decode an HTTP request body into the sparseBundleHeader struct
-	if err := plist.NewDecoder(r.Body).Decode(&sparseBundleHeader); err != nil {
+	if err := plist.NewXMLDecoder(r.Body).Decode(&sparseBundleHeader); err != nil {
 		log.Println(err)
         return
 	}


### PR DESCRIPTION
Assuming the code is correct we should be using `NewXMLDecoder` instead of `NewDecoder`. Right now it looks like both functions do the same thing.