### PR TITLE
Add tests for the "-" tag that skips decoding/encoding

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -494,3 +494,22 @@ func TestSmallInput(t *testing.T) {
 	}
 
 }
+
+func TestDecodeTagSkip(t *testing.T) {
+	const input = `<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>NoTag</key><string>NoTag</string><key>OtherTag</key><string>Tag</string><key>SkipTag</key><string>SkipTag</string></dict></plist>`
+	// Test struct
+	testStruct := struct {
+		NoTag   string
+		Tag     string `plist:"OtherTag"`
+		SkipTag string `plist:"-"`
+	}{}
+
+	if err := Unmarshal([]byte(input), &testStruct); err != nil {
+		t.Fatal(err)
+	}
+
+	if testStruct.SkipTag != "" {
+		t.Error("field decoded when it was tagged as -")
+	}
+}

--- a/encode_test.go
+++ b/encode_test.go
@@ -325,3 +325,25 @@ func TestSelfClosing(t *testing.T) {
 	}
 
 }
+
+func TestEncodeTagSkip(t *testing.T) {
+	// Test struct
+	testStruct := struct {
+		NoTag   string
+		Tag     string `plist:"OtherTag"`
+		SkipTag string `plist:"-"`
+	}{
+		NoTag:   "NoTag",
+		Tag:     "Tag",
+		SkipTag: "SkipTag",
+	}
+
+	have, err := Marshal(&testStruct)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Contains([]byte(have), []byte(testStruct.SkipTag)) {
+		t.Error("field encoded when it was tagged as -")
+	}
+}


### PR DESCRIPTION
Turns out #34 is already implemented:

https://github.com/groob/plist/blob/9f754062e6d698cf59e0d9b2feeee01dbfa7d3b9/tags.go#L139-L141

This PR just adds additional tests for them.

Closes #34.