### PR TITLE
fix: use reflect.DeepEqual to check equality of incomparable structs

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -218,7 +218,7 @@ func isEmptyValue(v reflect.Value) bool {
 	case reflect.Interface, reflect.Ptr:
 		return v.IsNil()
 	case reflect.Struct:
-		return v.Interface() == reflect.Zero(v.Type()).Interface()
+		return reflect.DeepEqual(v.Interface(), reflect.Zero(v.Type()).Interface())
 	}
 	return false
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -117,6 +117,7 @@ var indentRefOmit = `<?xml version="1.0" encoding="UTF-8"?>
 
 type testStruct struct {
 	UnusedString string `plist:"unused-string"`
+	UnusedByte   []byte `plist:"unused-byte,omitempty"`
 }
 
 var encodeTests = []struct {
@@ -208,7 +209,7 @@ func TestIndent(t *testing.T) {
 		Size:                  4 * 1048576 * 1024 * 1024,
 		DiskImageBundleType:   "com.apple.diskimage.sparsebundle",
 		BackingStoreVersion:   1,
-		Unused:                testStruct{"unused"},
+		Unused:                testStruct{UnusedString: "unused"},
 	}
 	b, err := MarshalIndent(sparseBundleHeader, "   ")
 	if err != nil {
@@ -235,7 +236,7 @@ func TestOmitNotEmpty(t *testing.T) {
 		Size:                  4 * 1048576 * 1024 * 1024,
 		DiskImageBundleType:   "com.apple.diskimage.sparsebundle",
 		BackingStoreVersion:   1,
-		Unused:                testStruct{"unused"},
+		Unused:                testStruct{UnusedString: "unused"},
 	}
 	b, err := MarshalIndent(sparseBundleHeader, "   ")
 	if err != nil {


### PR DESCRIPTION
This fixes an encoding bug mentioned on the macadmins slack. There's an edge case with incomparable structs that causes a panic. Here's minimal reproduction:

```go
package main

import (
	"github.com/groob/plist"
)

type Struct struct {
	Field []byte
}

type Parent struct {
	Struct Struct `plist:",omitempty"`
}

func main() {
	p := &Parent{Struct{}}
	plist.Marshal(p)
}
```

This PR contains a fix (use `reflect.DeepEqual` instead of `==`) and updated tests against the edge case.