### PR TITLE
Fix unbounded parsing issues

### DIFF
--- a/binary_parser.go
+++ b/binary_parser.go
@@ -37,7 +37,7 @@ const maxObjectDepth = 128
 
 // maxObjectNodes bounds the TOTAL number of objects materialized while
 // decoding, defeating exponential-expansion inputs.
-const maxObjectNodes = 1 << 21 // ~2.1M
+var maxObjectNodes = 1 << 21 // ~2.1M
 
 // newBinaryParser takes in a ReadSeeker for the bytes of a binary plist and
 // returns a parser after reading the offset table and trailer.

--- a/binary_parser.go
+++ b/binary_parser.go
@@ -23,12 +23,21 @@ type plistTrailer struct {
 }
 
 type binaryParser struct {
-	OffsetTable   []uint64 // array of offsets for each object in plist
-	plistTrailer           // last 32 bytes of plist
-	io.ReadSeeker          // reader for plist data
+	OffsetTable   []uint64        // array of offsets for each object in plist
+	plistTrailer                  // last 32 bytes of plist
+	io.ReadSeeker                 // reader for plist data
+	inProgress    map[uint64]bool // indices currently on the recursion stack (cycle detection)
+	depth         int             // current recursion depth
+	nodes         int             // total materialized objects so far (expansion budget)
 }
 
-const numObjectsMax = 4 << 20
+// maxObjectDepth bounds binary-plist reference nesting to prevent
+// stack exhaustion.
+const maxObjectDepth = 128
+
+// maxObjectNodes bounds the TOTAL number of objects materialized while
+// decoding, defeating exponential-expansion inputs.
+const maxObjectNodes = 1 << 21 // ~2.1M
 
 // newBinaryParser takes in a ReadSeeker for the bytes of a binary plist and
 // returns a parser after reading the offset table and trailer.
@@ -44,21 +53,32 @@ func newBinaryParser(r io.ReadSeeker) (*binaryParser, error) {
 		return nil, fmt.Errorf("plist: couldn't read trailer: %v", err)
 	}
 
+	if bp.OffsetIntSize == 0 || bp.OffsetIntSize > 8 {
+		return nil, fmt.Errorf("plist: invalid offset int size %d", bp.OffsetIntSize)
+	}
+	if bp.ObjectRefSize == 0 || bp.ObjectRefSize > 8 {
+		return nil, fmt.Errorf("plist: invalid object ref size %d", bp.ObjectRefSize)
+	}
+
+	fileLen, err := bp.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, err
+	}
+	// Offsets live in [OffsetTableOffset, fileLen-trailerSize); each is OffsetIntSize bytes.
+	if bp.OffsetTableOffset > uint64(fileLen) ||
+		bp.NumObjects > (uint64(fileLen)-bp.OffsetTableOffset)/uint64(bp.OffsetIntSize) {
+		return nil, fmt.Errorf("plist: NumObjects (%d) exceeds available data", bp.NumObjects)
+	}
+	if bp.RootObject >= bp.NumObjects {
+		return nil, fmt.Errorf("plist: root object ref out of range")
+	}
+
 	// Read the offset table.
 	if _, err := bp.Seek(int64(bp.OffsetTableOffset), io.SeekStart); err != nil {
 		return nil, fmt.Errorf("plist: couldn't seek to start of offset table: %v", err)
 	}
 
-	// numObjectsMax is arbitrary. Please fix.
-	// TODO(github.com/micromdm/plist/issues/28)
-	if bp.NumObjects > numObjectsMax {
-		return nil, fmt.Errorf("plist: offset size larger than expected %d", numObjectsMax)
-	}
-
 	bp.OffsetTable = make([]uint64, bp.NumObjects)
-	if bp.OffsetIntSize > 8 {
-		return nil, fmt.Errorf("plist: can't decode when offset int size (%d) is greater than 8", bp.OffsetIntSize)
-	}
 	for i := uint64(0); i < bp.NumObjects; i++ {
 		buf := make([]byte, 8)
 		if _, err := bp.Read(buf[8-bp.OffsetIntSize:]); err != nil {
@@ -66,6 +86,8 @@ func newBinaryParser(r io.ReadSeeker) (*binaryParser, error) {
 		}
 		bp.OffsetTable[i] = uint64(binary.BigEndian.Uint64(buf))
 	}
+
+	bp.inProgress = make(map[uint64]bool)
 
 	return &bp, nil
 }
@@ -82,6 +104,33 @@ func (bp *binaryParser) parseDocument() (*plistValue, error) {
 // This function restores the current plist offset when it's done so that you
 // may call it while decoding a collection object without losing your place.
 func (bp *binaryParser) parseObjectRef(index uint64) (val *plistValue, err error) {
+
+	if index >= uint64(len(bp.OffsetTable)) {
+		return nil, fmt.Errorf("plist: offset too large: %d", index)
+	}
+
+	// cyclic references
+	if bp.inProgress[index] {
+		return nil, fmt.Errorf("plist: cyclic object reference at index %d", index)
+	}
+
+	// total expansion budget
+	bp.nodes++
+	if bp.nodes > maxObjectNodes {
+		return nil, fmt.Errorf("plist: object graph exceeds maximum size (%d nodes)", maxObjectNodes)
+	}
+
+	// max depth check
+	if bp.depth >= maxObjectDepth {
+		return nil, fmt.Errorf("plist: object nesting exceeds maximum depth %d", maxObjectDepth)
+	}
+	bp.inProgress[index] = true
+	bp.depth++
+	defer func() {
+		delete(bp.inProgress, index)
+		bp.depth--
+	}()
+
 	// Save the current offset.
 	offset, err := bp.Seek(0, io.SeekCurrent)
 	if err != nil {
@@ -95,9 +144,6 @@ func (bp *binaryParser) parseObjectRef(index uint64) (val *plistValue, err error
 		}
 	}()
 
-	if index > uint64(len(bp.OffsetTable)) {
-		return nil, fmt.Errorf("plist: offset too large: %d", index)
-	}
 	// Move to the start of the object we want to decode.
 	if _, err := bp.Seek(int64(bp.OffsetTable[index]), io.SeekStart); err != nil {
 		return nil, err
@@ -249,6 +295,9 @@ func (bp *binaryParser) parseInteger(marker byte) (*plistValue, error) {
 
 func (bp *binaryParser) parseReal(marker byte) (*plistValue, error) {
 	nbytes := 1 << (marker & 0xf)
+	if nbytes > 8 {
+		return nil, fmt.Errorf("plist: real longer than 8 bytes (%d)", nbytes)
+	}
 	buf := make([]byte, nbytes)
 	if _, err := bp.Read(buf); err != nil {
 		return nil, err
@@ -297,6 +346,9 @@ func (bp *binaryParser) parseData(marker byte) (*plistValue, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := bp.checkCount(count, 1); err != nil {
+		return nil, err
+	}
 	buf := make([]byte, count)
 	if _, err := bp.Read(buf); err != nil {
 		return nil, err
@@ -309,6 +361,9 @@ func (bp *binaryParser) parseASCII(marker byte) (*plistValue, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := bp.checkCount(count, 1); err != nil {
+		return nil, err
+	}
 	buf := make([]byte, count)
 	if _, err := bp.Read(buf); err != nil {
 		return nil, err
@@ -319,6 +374,9 @@ func (bp *binaryParser) parseASCII(marker byte) (*plistValue, error) {
 func (bp *binaryParser) parseUTF16(marker byte) (*plistValue, error) {
 	count, err := bp.readCount(marker)
 	if err != nil {
+		return nil, err
+	}
+	if err := bp.checkCount(count, 2); err != nil {
 		return nil, err
 	}
 	// Each character in the UTF16 string is 2 bytes.  First we read everything
@@ -419,6 +477,9 @@ func (bp *binaryParser) readObjectRef() (uint64, error) {
 // It decodes a sequence of object refs from the current offset in the plist
 // and returns the decoded objects in a slice.
 func (bp *binaryParser) readObjectList(count uint64) ([]*plistValue, error) {
+	if err := bp.checkCount(count, uint64(bp.ObjectRefSize)); err != nil {
+		return nil, err
+	}
 	list := make([]*plistValue, count)
 	for i := uint64(0); i < count; i++ {
 		// Read index of object in offset table.
@@ -434,4 +495,30 @@ func (bp *binaryParser) readObjectList(count uint64) ([]*plistValue, error) {
 		list[i] = v
 	}
 	return list, nil
+}
+
+// remainingInObjects reports the bytes between the current read position and the
+// start of the offset table (the end of the object region).
+func (bp *binaryParser) remainingInObjects() (uint64, error) {
+	pos, err := bp.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return 0, err
+	}
+	if uint64(pos) >= bp.OffsetTableOffset {
+		return 0, nil
+	}
+	return bp.OffsetTableOffset - uint64(pos), nil
+}
+
+// checkCount rejects a declared element count that cannot fit in the remaining
+// object-region bytes (each element occupies at least unit bytes on the wire).
+func (bp *binaryParser) checkCount(count, unit uint64) error {
+	rem, err := bp.remainingInObjects()
+	if err != nil {
+		return err
+	}
+	if unit == 0 || count > rem/unit {
+		return fmt.Errorf("plist: declared object size (%d) exceeds remaining input", count)
+	}
+	return nil
 }

--- a/binary_parser.go
+++ b/binary_parser.go
@@ -29,6 +29,7 @@ type binaryParser struct {
 	inProgress    map[uint64]bool // indices currently on the recursion stack (cycle detection)
 	depth         int             // current recursion depth
 	nodes         int             // total materialized objects so far (expansion budget)
+	bytes         uint64          // total data/string bytes materialized so far (size budget)
 }
 
 // maxObjectDepth bounds binary-plist reference nesting to prevent
@@ -38,6 +39,20 @@ const maxObjectDepth = 128
 // maxObjectNodes bounds the TOTAL number of objects materialized while
 // decoding, defeating exponential-expansion inputs.
 var maxObjectNodes = 1 << 21 // ~2.1M
+
+// headerSize is the fixed "bplist00" magic; trailerSize is the fixed 32-byte
+// trailer. Object offsets live in [headerSize, OffsetTableOffset).
+const (
+	headerSize  = 8
+	trailerSize = 32
+)
+
+// maxObjectBytes bounds the TOTAL bytes materialized into data and string
+// objects while decoding. maxObjectNodes bounds object COUNT; this bounds their
+// aggregate SIZE, so a small input that references a large object many times
+// (byte amplification) cannot be inflated into unbounded memory the node budget
+// alone would not catch.
+var maxObjectBytes uint64 = 1 << 26 // 64MB
 
 // newBinaryParser takes in a ReadSeeker for the bytes of a binary plist and
 // returns a parser after reading the offset table and trailer.
@@ -64,10 +79,21 @@ func newBinaryParser(r io.ReadSeeker) (*binaryParser, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Offsets live in [OffsetTableOffset, fileLen-trailerSize); each is OffsetIntSize bytes.
-	if bp.OffsetTableOffset > uint64(fileLen) ||
-		bp.NumObjects > (uint64(fileLen)-bp.OffsetTableOffset)/uint64(bp.OffsetIntSize) {
+	// The offset table lives after the header and before the trailer.
+	if bp.OffsetTableOffset < headerSize || bp.OffsetTableOffset > uint64(fileLen)-trailerSize {
+		return nil, fmt.Errorf("plist: offset table offset (%d) out of range", bp.OffsetTableOffset)
+	}
+	// The table holds NumObjects entries of OffsetIntSize bytes each and must fit
+	// between the object region and the trailer.
+	if bp.NumObjects > (uint64(fileLen)-trailerSize-bp.OffsetTableOffset)/uint64(bp.OffsetIntSize) {
 		return nil, fmt.Errorf("plist: NumObjects (%d) exceeds available data", bp.NumObjects)
+	}
+	// Every object occupies at least its 1-byte marker in the object region
+	// [headerSize, OffsetTableOffset), so there cannot be more objects than
+	// object-region bytes. This bounds the offset-table allocation below to the
+	// file size regardless of the OffsetIntSize amplification factor.
+	if bp.NumObjects > bp.OffsetTableOffset-headerSize {
+		return nil, fmt.Errorf("plist: NumObjects (%d) exceeds object region", bp.NumObjects)
 	}
 	if bp.RootObject >= bp.NumObjects {
 		return nil, fmt.Errorf("plist: root object ref out of range")
@@ -81,10 +107,16 @@ func newBinaryParser(r io.ReadSeeker) (*binaryParser, error) {
 	bp.OffsetTable = make([]uint64, bp.NumObjects)
 	for i := uint64(0); i < bp.NumObjects; i++ {
 		buf := make([]byte, 8)
-		if _, err := bp.Read(buf[8-bp.OffsetIntSize:]); err != nil {
+		if _, err := io.ReadFull(bp, buf[8-bp.OffsetIntSize:]); err != nil {
 			return nil, fmt.Errorf("plist: couldn't read offset table: %v", err)
 		}
-		bp.OffsetTable[i] = uint64(binary.BigEndian.Uint64(buf))
+		// Each entry must point into the object region; a scalar object at an
+		// out-of-region offset would otherwise decode to silent garbage.
+		off := binary.BigEndian.Uint64(buf)
+		if off < headerSize || off >= bp.OffsetTableOffset {
+			return nil, fmt.Errorf("plist: object offset %d out of range", off)
+		}
+		bp.OffsetTable[i] = off
 	}
 
 	bp.inProgress = make(map[uint64]bool)
@@ -281,7 +313,7 @@ func (bp *binaryParser) parseInteger(marker byte) (*plistValue, error) {
 	}
 	// Read into the right-most bytes of a 16-byte zero-valued buffer.
 	buf := make([]byte, 16)
-	_, err := bp.Read(buf[16-nbytes:])
+	_, err := io.ReadFull(bp, buf[16-nbytes:])
 	if err != nil {
 		return nil, err
 	}
@@ -299,7 +331,7 @@ func (bp *binaryParser) parseReal(marker byte) (*plistValue, error) {
 		return nil, fmt.Errorf("plist: real longer than 8 bytes (%d)", nbytes)
 	}
 	buf := make([]byte, nbytes)
-	if _, err := bp.Read(buf); err != nil {
+	if _, err := io.ReadFull(bp, buf); err != nil {
 		return nil, err
 	}
 	var r float64
@@ -314,7 +346,7 @@ func (bp *binaryParser) parseDate(marker byte) (*plistValue, error) {
 		return nil, fmt.Errorf("plist: invalid marker byte for date: %x", marker)
 	}
 	buf := make([]byte, 8)
-	if _, err := bp.Read(buf); err != nil {
+	if _, err := io.ReadFull(bp, buf); err != nil {
 		return nil, err
 	}
 	var t float64
@@ -335,10 +367,23 @@ func (bp *binaryParser) parseUID(marker byte) (*plistValue, error) {
 		return nil, fmt.Errorf("plist: UID too large: %d bytes", nbytes)
 	}
 	buf := make([]byte, 8)
-	if _, err := bp.Read(buf[8-nbytes:]); err != nil {
+	if _, err := io.ReadFull(bp, buf[8-nbytes:]); err != nil {
 		return nil, err
 	}
 	return &plistValue{CFUID, UID(binary.BigEndian.Uint64(buf))}, nil
+}
+
+// accountBytes adds n to the running total of bytes materialized into data and
+// string objects and rejects the document once it exceeds maxObjectBytes. The
+// node budget bounds how many objects are decoded; this bounds their aggregate
+// size, so a small input referencing a large object many times cannot be
+// amplified into unbounded memory.
+func (bp *binaryParser) accountBytes(n uint64) error {
+	bp.bytes += n
+	if bp.bytes > maxObjectBytes {
+		return fmt.Errorf("plist: decoded data exceeds maximum size (%d bytes)", maxObjectBytes)
+	}
+	return nil
 }
 
 func (bp *binaryParser) parseData(marker byte) (*plistValue, error) {
@@ -349,8 +394,11 @@ func (bp *binaryParser) parseData(marker byte) (*plistValue, error) {
 	if err := bp.checkCount(count, 1); err != nil {
 		return nil, err
 	}
+	if err := bp.accountBytes(count); err != nil {
+		return nil, err
+	}
 	buf := make([]byte, count)
-	if _, err := bp.Read(buf); err != nil {
+	if _, err := io.ReadFull(bp, buf); err != nil {
 		return nil, err
 	}
 	return &plistValue{Data, buf}, nil
@@ -364,8 +412,11 @@ func (bp *binaryParser) parseASCII(marker byte) (*plistValue, error) {
 	if err := bp.checkCount(count, 1); err != nil {
 		return nil, err
 	}
+	if err := bp.accountBytes(count); err != nil {
+		return nil, err
+	}
 	buf := make([]byte, count)
-	if _, err := bp.Read(buf); err != nil {
+	if _, err := io.ReadFull(bp, buf); err != nil {
 		return nil, err
 	}
 	return &plistValue{String, string(buf)}, nil
@@ -379,11 +430,14 @@ func (bp *binaryParser) parseUTF16(marker byte) (*plistValue, error) {
 	if err := bp.checkCount(count, 2); err != nil {
 		return nil, err
 	}
+	if err := bp.accountBytes(2 * count); err != nil {
+		return nil, err
+	}
 	// Each character in the UTF16 string is 2 bytes.  First we read everything
 	// into a byte slice, then convert this into a slice of uint16, then this
 	// gets converted into a slice of rune, which gets converted to a string.
 	buf := make([]byte, 2*count)
-	if _, err := bp.Read(buf); err != nil {
+	if _, err := io.ReadFull(bp, buf); err != nil {
 		return nil, err
 	}
 	uni := make([]uint16, count)
@@ -457,7 +511,7 @@ func (bp *binaryParser) readCount(marker byte) (uint64, error) {
 	}
 	buf := make([]byte, 8)
 	// Shove these bytes into the low end of an 8-byte buffer.
-	if _, err := bp.Read(buf[8-nbytes:]); err != nil {
+	if _, err := io.ReadFull(bp, buf[8-nbytes:]); err != nil {
 		return 0, err
 	}
 	return binary.BigEndian.Uint64(buf), nil
@@ -467,7 +521,7 @@ func (bp *binaryParser) readCount(marker byte) (uint64, error) {
 // and returns the bytes decoded into an integer value.
 func (bp *binaryParser) readObjectRef() (uint64, error) {
 	buf := make([]byte, 8)
-	if _, err := bp.Read(buf[8-bp.ObjectRefSize:]); err != nil {
+	if _, err := io.ReadFull(bp, buf[8-bp.ObjectRefSize:]); err != nil {
 		return 0, err
 	}
 	return binary.BigEndian.Uint64(buf), nil

--- a/binary_parser_test.go
+++ b/binary_parser_test.go
@@ -1,0 +1,160 @@
+package plist
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+	"time"
+)
+
+//  1. Self-reference: object 0 is an array whose only element points back at 0.
+//     Must error ("cyclic"), never overflow the stack.
+func TestBinaryParserSelfReference(t *testing.T) {
+	data := buildBinaryPlist([][]byte{arrayObj([]uint64{0}, 1)}, 0, 1)
+	var out interface{}
+	err := Unmarshal(data, &out)
+	if err == nil || !strings.Contains(err.Error(), "cyclic") {
+		t.Fatalf("want cyclic-reference error, got %v", err)
+	}
+}
+
+//  2. Exponential doubling chain: obj i = [i+1, i+1]; would expand to 2^40 nodes.
+//     The node budget must reject it QUICKLY (finish well under the timeout AND
+//     return an error). This is the case parse-layer memoization alone fails.
+func TestBinaryParserExponentialFanout(t *testing.T) {
+	const n = 40
+	objs := make([][]byte, n+1)
+	for i := 0; i < n; i++ {
+		objs[i] = arrayObj([]uint64{uint64(i + 1), uint64(i + 1)}, 2)
+	}
+	objs[n] = asciiObj("leaf")
+	data := buildBinaryPlist(objs, 0, 2)
+
+	type res struct{ err error }
+	ch := make(chan res, 1)
+	go func() { var out interface{}; ch <- res{Unmarshal(data, &out)} }()
+	select {
+	case r := <-ch:
+		if r.err == nil || !strings.Contains(r.err.Error(), "object graph exceeds maximum size") {
+			t.Fatal("want error: exponential graph should be rejected by the node budget")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Unmarshal did not finish; exponential expansion is not bounded")
+	}
+}
+
+// 3. Deep linear chain deeper than maxObjectDepth: must error ("depth"), not overflow.
+func TestBinaryParserMaxDepth(t *testing.T) {
+	const n = maxObjectDepth + 5
+	objs := make([][]byte, n+1)
+	for i := 0; i < n; i++ {
+		objs[i] = arrayObj([]uint64{uint64(i + 1)}, 2)
+	}
+	objs[n] = asciiObj("leaf")
+	data := buildBinaryPlist(objs, 0, 2)
+	var out interface{}
+	err := Unmarshal(data, &out)
+	if err == nil || !strings.Contains(err.Error(), "depth") {
+		t.Fatalf("want max-depth error, got %v", err)
+	}
+}
+
+//  4. Valid, modestly-shared plist (regression): a dict decodes correctly.
+//     Ensures the guards don't reject legitimate input.
+func TestBinaryParserValidDict(t *testing.T) {
+	dict := []byte{0xd2, 1, 2, 3, 4} // count=2; key refs 1,2; value refs 3,4 (refSize 1)
+	objs := [][]byte{dict, asciiObj("a"), asciiObj("b"), asciiObj("x"), asciiObj("y")}
+	data := buildBinaryPlist(objs, 0, 1)
+	var out map[string]string
+	if err := Unmarshal(data, &out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["a"] != "x" || out["b"] != "y" {
+		t.Fatalf("decoded wrong: %#v", out)
+	}
+}
+
+// 5. Off-by-one: RootObject == NumObjects (one past the table).
+func TestBinaryParserRootOutOfRange(t *testing.T) {
+	data := buildBinaryPlist([][]byte{asciiObj("x")}, 1, 1)
+	var out interface{}
+	err := Unmarshal(data, &out)
+	if err == nil || !strings.Contains(err.Error(), "out of range") {
+		t.Fatalf("want out-of-range error, got %v", err)
+	}
+}
+
+func TestBinaryParserChildRefOutOfRange(t *testing.T) {
+	// Only object 0 exists; its array element points at nonexistent index 1.
+	data := buildBinaryPlist([][]byte{arrayObj([]uint64{1}, 1)}, 0, 1)
+	var out interface{}
+	err := Unmarshal(data, &out)
+	if err == nil || !strings.Contains(err.Error(), "offset too large") {
+		t.Fatalf("want offset-too-large error, got %v", err)
+	}
+}
+
+//  6. Issue #28 allocation guard: tiny buffer whose trailer claims a huge NumObjects.
+//     Must error cleanly with no large allocation. (Requires the #28 hardening.)
+func TestBinaryParserInflatedNumObjects(t *testing.T) {
+	data := buildBinaryPlist([][]byte{asciiObj("x")}, 0, 1)
+	// Overwrite NumObjects in the trailer (bytes [len-24, len-16)).
+	binary.BigEndian.PutUint64(data[len(data)-24:len(data)-16], 1<<40)
+	var out interface{}
+	if err := Unmarshal(data, &out); err == nil || !strings.Contains(err.Error(), "exceeds available data") {
+		t.Fatal("want error for inflated NumObjects")
+	}
+}
+
+func TestBinaryParserZeroOffsetIntSize(t *testing.T) {
+	data := buildBinaryPlist([][]byte{asciiObj("x")}, 0, 1)
+	data[len(data)-32+6] = 0 // OffsetIntSize byte in the trailer
+	var out interface{}
+	if err := Unmarshal(data, &out); err == nil {
+		t.Fatal("want error, got nil")
+	}
+}
+func TestBinaryParserHugeObjectRefSize(t *testing.T) {
+	data := buildBinaryPlist([][]byte{arrayObj([]uint64{0}, 1)}, 0, 1)
+	data[len(data)-32+7] = 9 // ObjectRefSize byte in the trailer
+	var out interface{}
+	if err := Unmarshal(data, &out); err == nil {
+		t.Fatal("want error, got nil")
+	}
+}
+
+func buildBinaryPlist(objects [][]byte, root uint64, refSize uint8) []byte {
+	buf := []byte("bplist00")
+	offsets := make([]uint64, len(objects))
+	for i, o := range objects {
+		offsets[i] = uint64(len(buf))
+		buf = append(buf, o...)
+	}
+	offsetTableOffset := uint64(len(buf))
+	for _, off := range offsets {
+		var b [8]byte
+		binary.BigEndian.PutUint64(b[:], off)
+		buf = append(buf, b[:]...)
+	}
+	var tr [32]byte
+	tr[6] = 8                                                  // OffsetIntSize
+	tr[7] = refSize                                            // ObjectRefSize
+	binary.BigEndian.PutUint64(tr[8:16], uint64(len(objects))) // NumObjects
+	binary.BigEndian.PutUint64(tr[16:24], root)                // RootObject
+	binary.BigEndian.PutUint64(tr[24:32], offsetTableOffset)   // OffsetTableOffset
+	return append(buf, tr[:]...)
+}
+
+// arrayObj encodes an array object (<15 elements) with the given element refs.
+func arrayObj(refs []uint64, refSize uint8) []byte {
+	o := []byte{0xa0 | byte(len(refs))}
+	for _, r := range refs {
+		var b [8]byte
+		binary.BigEndian.PutUint64(b[:], r)
+		o = append(o, b[8-refSize:]...)
+	}
+	return o
+}
+
+// asciiObj encodes a short (<15 char) ASCII string object.
+func asciiObj(s string) []byte { return append([]byte{0x50 | byte(len(s))}, s...) }

--- a/binary_parser_test.go
+++ b/binary_parser_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"strings"
 	"testing"
-	"time"
 )
 
 //  1. Self-reference: object 0 is an array whose only element points back at 0.
@@ -22,6 +21,11 @@ func TestBinaryParserSelfReference(t *testing.T) {
 //     The node budget must reject it QUICKLY (finish well under the timeout AND
 //     return an error). This is the case parse-layer memoization alone fails.
 func TestBinaryParserExponentialFanout(t *testing.T) {
+	// Shrink the budget so the guard trips almost immediately — we're
+	// verifying the guard fires, not how fast it counts to 2 million.
+	defer func(n int) { maxObjectNodes = n }(maxObjectNodes)
+	maxObjectNodes = 1000
+
 	const n = 40
 	objs := make([][]byte, n+1)
 	for i := 0; i < n; i++ {
@@ -30,16 +34,10 @@ func TestBinaryParserExponentialFanout(t *testing.T) {
 	objs[n] = asciiObj("leaf")
 	data := buildBinaryPlist(objs, 0, 2)
 
-	type res struct{ err error }
-	ch := make(chan res, 1)
-	go func() { var out interface{}; ch <- res{Unmarshal(data, &out)} }()
-	select {
-	case r := <-ch:
-		if r.err == nil || !strings.Contains(r.err.Error(), "object graph exceeds maximum size") {
-			t.Fatal("want error: exponential graph should be rejected by the node budget")
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("Unmarshal did not finish; exponential expansion is not bounded")
+	var out interface{}
+	err := Unmarshal(data, &out)
+	if err == nil || !strings.Contains(err.Error(), "object graph exceeds maximum size") {
+		t.Fatalf("want maximum-size error, got %v", err)
 	}
 }
 

--- a/binary_parser_test.go
+++ b/binary_parser_test.go
@@ -1,7 +1,9 @@
 package plist
 
 import (
+	"bytes"
 	"encoding/binary"
+	"io"
 	"strings"
 	"testing"
 )
@@ -118,6 +120,115 @@ func TestBinaryParserHugeObjectRefSize(t *testing.T) {
 	var out interface{}
 	if err := Unmarshal(data, &out); err == nil {
 		t.Fatal("want error, got nil")
+	}
+}
+
+// Byte amplification: a small array whose many refs all point at one large
+// object. The node budget (object COUNT) never trips, but the aggregate SIZE
+// budget must, so the decode cannot be inflated into unbounded memory.
+func TestBinaryParserByteAmplification(t *testing.T) {
+	defer func(n uint64) { maxObjectBytes = n }(maxObjectBytes)
+	maxObjectBytes = 25
+
+	// obj0: array of 5 refs, all -> obj1. obj1: a 10-byte string.
+	// Re-materializing obj1 five times is 50 bytes > the 25-byte budget.
+	data := buildBinaryPlist([][]byte{
+		arrayObj([]uint64{1, 1, 1, 1, 1}, 1),
+		asciiObj("0123456789"),
+	}, 0, 1)
+
+	var out interface{}
+	err := Unmarshal(data, &out)
+	if err == nil || !strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Fatalf("want size-budget error, got %v", err)
+	}
+}
+
+// An offset-table entry that points outside the object region must be rejected.
+// A scalar object at such an offset would otherwise decode to silent garbage
+// (it never reaches the checkCount guard that catches collections/strings).
+func TestBinaryParserOffsetOutOfRange(t *testing.T) {
+	data := buildBinaryPlist([][]byte{asciiObj("x")}, 0, 1)
+	// OffsetTableOffset is the trailer's last 8 bytes; offset entry 0 sits there
+	// (buildBinaryPlist writes 8-byte offsets). Point it at the table itself.
+	otoff := binary.BigEndian.Uint64(data[len(data)-8:])
+	binary.BigEndian.PutUint64(data[otoff:otoff+8], otoff)
+	var out interface{}
+	err := Unmarshal(data, &out)
+	if err == nil || !strings.Contains(err.Error(), "out of range") {
+		t.Fatalf("want offset-out-of-range error, got %v", err)
+	}
+}
+
+// NumObjects inflated past the object region (more objects than bytes that can
+// hold their markers) must be rejected before the offset table is allocated,
+// even when NumObjects still fits the raw file (the make([]uint64, N) OOM path).
+func TestBinaryParserNumObjectsExceedsObjectRegion(t *testing.T) {
+	// Hand-built: 8-byte header, one 1-byte object (bool true) at offset 8, then
+	// a 100-entry 1-byte offset table, then the trailer. NumObjects=100 fits the
+	// file but far exceeds the 1-byte object region.
+	const numObjects = 100
+	buf := []byte("bplist00")
+	buf = append(buf, 0x09) // object 0: boolean true, at offset 8
+	otoff := uint64(len(buf))
+	for i := 0; i < numObjects; i++ {
+		buf = append(buf, 8) // every 1-byte offset -> the boolean at offset 8
+	}
+	var tr [32]byte
+	tr[6] = 1 // OffsetIntSize
+	tr[7] = 1 // ObjectRefSize
+	binary.BigEndian.PutUint64(tr[8:16], numObjects)
+	binary.BigEndian.PutUint64(tr[16:24], 0) // RootObject
+	binary.BigEndian.PutUint64(tr[24:32], otoff)
+	buf = append(buf, tr[:]...)
+
+	var out interface{}
+	err := Unmarshal(buf, &out)
+	if err == nil || !strings.Contains(err.Error(), "exceeds object region") {
+		t.Fatalf("want object-region error, got %v", err)
+	}
+}
+
+// oneByteReader wraps an io.ReadSeeker but returns at most one byte per Read,
+// which io.Reader permits. It models a streaming/custom ReadSeeker (not a
+// bytes.Reader) to prove multi-byte fields are read with io.ReadFull rather than
+// a single Read that would silently zero-fill the unread tail.
+type oneByteReader struct{ rs io.ReadSeeker }
+
+func (r oneByteReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return r.rs.Read(p[:1])
+}
+
+func (r oneByteReader) Seek(offset int64, whence int) (int64, error) {
+	return r.rs.Seek(offset, whence)
+}
+
+// A valid plist must decode correctly even through a reader that never fills a
+// multi-byte buffer in one call: 8-byte offsets, the 2-byte integer, and the
+// multi-char strings all depend on the full buffer being read.
+func TestBinaryParserShortReads(t *testing.T) {
+	objs := [][]byte{
+		{0xd2, 1, 2, 3, 4}, // dict: key refs 1,2; value refs 3,4 (refSize 1)
+		asciiObj("num"),    // key 0
+		asciiObj("str"),    // key 1
+		{0x11, 0x01, 0x02}, // integer 258, encoded in 2 bytes
+		asciiObj("hello"),  // value 1
+	}
+	data := buildBinaryPlist(objs, 0, 1)
+
+	var out struct {
+		Num int    `plist:"num"`
+		Str string `plist:"str"`
+	}
+	dec := NewBinaryDecoder(oneByteReader{bytes.NewReader(data)})
+	if err := dec.Decode(&out); err != nil {
+		t.Fatalf("decode through short reader failed: %v", err)
+	}
+	if out.Num != 258 || out.Str != "hello" {
+		t.Fatalf("decoded wrong through short reader: %+v", out)
 	}
 }
 


### PR DESCRIPTION
This PR fixes a couple of bugs/issues with unbounded plist parsing.

1. Block cyclic references, to avoid stack overflow crash. (Cap on 128 node depth, even though a handful should be enough, I thought giving a generous amount should be okay here)
2. Exponential expansion via a doubling graph, cap at 2.1M materialised nodes, which should return an error fast even though the number seems high.
3. Allocation amplification, checks the declared count against remaining input bytes, before reserving memory.
4. NumObjects is now bounded by the actual file size, rather than arbitrary limit (Should fix #28)
5. Fixed an off-by-one index issue in `parseObjectRef`
6. Fixed `parseReal` to error on higher than 8 byte allocation.


Verified via a new ADE enrollment, that no issues appear in PLIST parsing.